### PR TITLE
Fix package name in pip install command

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@ As a component framework for Django, Tetra requires that you have a Django proje
 Once ready install Tetra from PyPi:
 
 ```
-$ pip install tetra-framework
+$ pip install tetraframework
 ```
 
 > **Note:** As Tetra is still being developed it has only been tested with Python 3.9 and 3.10, we intend to support at least 3.8 before a V1 release.


### PR DESCRIPTION
The project seems to reside at https://pypi.org/project/tetraframework/ and running the command in the doc fails with

```
  Could not find a matching version of package tetra-framework

  at /usr/local/lib/python3.9/site-packages/poetry/console/commands/init.py:381 in _find_best_version_for_package
      377│         )
      378│
      379│         if not package:
      380│             # TODO: find similar
    → 381│             raise ValueError(
      382│                 "Could not find a matching version of package {}".format(name)
      383│             )
      384│
      385│         return package.pretty_name, selector.find_recommended_require_version(package)
```