### PR TITLE
Doc fix link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ pip install tetraframework
 
   - Syntax highlighting with type annotations
 
-    Tetra uses type annotations to syntax highlight your JS, CSS & HTML in your Python files with a [VS Code plugin](https://github.com/samwillis/python-inline-source/tree/main/vscode-python-inline-sources)
+    Tetra uses type annotations to syntax highlight your JS, CSS & HTML in your Python files with a [VS Code plugin](https://github.com/samwillis/python-inline-source/tree/main/vscode-python-inline-source)


### PR DESCRIPTION
There is an extra `s` at the end of this(https://github.com/samwillis/python-inline-source/tree/main/vscode-python-inline-sources) link